### PR TITLE
[Minor] Composer package name should be `schumacherfm`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":"schumacher-fm/optimized-backend-login",
+    "name":"schumacherfm/optimized-backend-login",
     "type":"magento-module",
     "license":"OSL-3.0",
     "homepage":"https://github.com/SchumacherFM/Magento-OptimizedBackendLogin",


### PR DESCRIPTION
All other SchumacherFM Composer packages are in the `schumacherfm` namespace. However, this one is in `schumacher-fm`.

If this change is accepted, this repo will need to be resubmitted to Packagist. Also, the old package should be marked as "Abandoned" on Packagist.org so that people are redirected to the new name when trying to install using the old one.